### PR TITLE
feat: Change package name to @zdpk/gpx

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "gpx",
+  "name": "@zdpk/gpx",
   "version": "0.0.1",
   "description": "GitHub Package eXecutor - Run GitHub release binaries directly",
   "main": "dist/index.js",


### PR DESCRIPTION
- Update package name in package.json to a scoped package (@zdpk/gpx).
- This helps prevent naming conflicts on npm and simplifies ownership management.
- This PR addresses the EPUBLISHCONFLICT and E403 Forbidden errors encountered during npm publish.